### PR TITLE
Refine lobby presence and admin controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,719 +1,2190 @@
 <!DOCTYPE html>
-<html lang="zh-Hant">
+<html lang="zh-TW">
 <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>圖片庫儲存測試</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>花枝鼠社群專用 - 臨時私密對話小工具</title>
+
+    <!-- Firebase SDK -->
+    <script type="module">
+        import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js';
+        import { getDatabase, ref, push, onValue, remove, set, onDisconnect, query, orderByChild, limitToLast } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-database.js';
+
+        const firebaseConfig = {
+            apiKey: "AIzaSyA3Ml5IrxQAX1s9W03y_yRjU1xELR_kNF8",
+            authDomain: "rat50khz.firebaseapp.com",
+            databaseURL: "https://rat50khz-default-rtdb.asia-southeast1.firebasedatabase.app",
+            projectId: "rat50khz",
+            storageBucket: "rat50khz.firebasestorage.app",
+            messagingSenderId: "259578799109",
+            appId: "1:259578799109:web:2faaf07c2a5ca202b0686c",
+            measurementId: "G-CRM8NDPK0G"
+        };
+
+        const app = initializeApp(firebaseConfig);
+        const database = getDatabase(app);
+
+        window.firebaseDB = database;
+        window.firebaseRef = ref;
+        window.firebasePush = push;
+        window.firebaseOnValue = onValue;
+        window.firebaseRemove = remove;
+        window.firebaseSet = set;
+        window.firebaseOnDisconnect = onDisconnect;
+        window.firebaseQuery = query;
+        window.firebaseOrderByChild = orderByChild;
+        window.firebaseLimitToLast = limitToLast;
+    </script>
+
     <style>
-        body {
-            font-family: "Noto Sans TC", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-            background: #f2f4f5;
+        @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&family=Nunito:wght@300;400;500;600;700&display=swap');
+
+        * {
             margin: 0;
-            padding: 2rem;
-            color: #1f2933;
+            padding: 0;
+            box-sizing: border-box;
+            font-family: 'Nunito', 'Noto Sans TC', sans-serif;
+        }
+
+        body {
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: flex-start;
+            padding: 28px 18px 24px;
+            transition: background-color 0.5s;
+        }
+
+        body.logged-in {
+            align-items: flex-start;
+        }
+
+        .container {
+            width: 100%;
+            max-width: 640px;
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .headline {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .headline-row {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 14px;
+            flex-wrap: wrap;
+        }
+
+        .container.rooms-visible {
+            gap: 28px;
         }
 
         h1 {
-            margin-bottom: 1rem;
-            font-size: 1.75rem;
+            font-size: 42px;
+            font-weight: 700;
+            text-align: center;
+            letter-spacing: 3px;
+            color: #5A4A3D;
         }
 
-        .panel {
-            background: white;
-            border-radius: 16px;
-            box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.35);
-            padding: 24px;
-            max-width: 880px;
-            margin: 0 auto;
+        h2 {
+            font-size: 26px;
+            font-weight: 400;
+            text-align: center;
+            letter-spacing: 2px;
+            color: #7A6A5D;
         }
 
-        .input-row {
-            margin-bottom: 1.5rem;
-        }
-
-        .input-row label {
-            display: block;
-            font-weight: 600;
-            margin-bottom: 0.5rem;
-        }
-
-        input[type="text"],
-        input[type="file"] {
-            width: 100%;
-            padding: 0.65rem 0.75rem;
-            border: 1px solid #cbd2d9;
-            border-radius: 10px;
-            font-size: 1rem;
-        }
-
-        .actions {
+        .lobby-indicator {
             display: flex;
-            flex-wrap: wrap;
-            gap: 0.75rem;
-        }
-
-        button {
-            border: none;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 12px;
             border-radius: 999px;
-            padding: 0.65rem 1.5rem;
-            font-size: 0.95rem;
-            font-weight: 600;
-            cursor: pointer;
-            transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+            background: rgba(255, 255, 255, 0.12);
+            border: 1px solid rgba(255, 255, 255, 0.25);
         }
 
-        button.primary {
-            background: linear-gradient(135deg, #8ab4f8, #5a8dee);
-            color: white;
-            box-shadow: 0 10px 20px -10px rgba(66, 133, 244, 0.7);
-        }
-
-        button.secondary {
-            background: rgba(113, 128, 150, 0.14);
-            color: #334155;
-        }
-
-        button:active {
-            transform: scale(0.97);
-        }
-
-        .gallery {
-            margin-top: 2rem;
-            display: grid;
-            gap: 1rem;
-            grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-        }
-
-        .card {
-            position: relative;
-            border-radius: 14px;
-            overflow: hidden;
-            background: #f8fafc;
-            box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
-        }
-
-        .card img {
-            display: block;
-            width: 100%;
-            height: 150px;
-            object-fit: cover;
-        }
-
-        .card .caption {
-            padding: 0.5rem 0.75rem;
-            font-size: 0.8rem;
-            background: rgba(15, 23, 42, 0.72);
-            color: white;
-        }
-
-        .card .overlay {
-            position: absolute;
-            inset: 0;
+        .lobby-lamp {
             display: flex;
             align-items: center;
             justify-content: center;
-            background: rgba(15, 23, 42, 0.55);
-            opacity: 0;
-            transition: opacity 0.2s ease;
-            color: white;
+        }
+
+        .lobby-lamp svg {
+            width: 16px;
+            height: 16px;
+            fill: rgba(255, 255, 255, 0.35);
+        }
+
+        .lobby-lamp.on svg {
+            fill: #4CAF50;
+            filter: drop-shadow(0 0 6px rgba(76, 175, 80, 0.45));
+        }
+
+        .lobby-status-text {
+            font-size: 14px;
             font-weight: 600;
-            text-align: center;
-            padding: 0.5rem;
+            color: #F7F1EA;
         }
 
-        .card:hover .overlay {
-            opacity: 1;
-        }
-
-        .storage-info {
-            margin-top: 1rem;
-            font-size: 0.9rem;
-            color: #475569;
-        }
-
-        .toast {
-            position: fixed;
-            top: 24px;
-            right: 24px;
-            background: rgba(15, 23, 42, 0.92);
-            color: white;
-            padding: 0.9rem 1.2rem;
-            border-radius: 12px;
-            font-size: 0.95rem;
-            box-shadow: 0 20px 40px -20px rgba(15, 23, 42, 0.8);
-            opacity: 0;
-            transform: translateY(-8px);
-            pointer-events: none;
-            transition: opacity 0.25s ease, transform 0.25s ease;
-            z-index: 1200;
-        }
-
-        .toast.show {
-            opacity: 1;
-            transform: translateY(0);
-        }
-
-        .context-menu {
-            position: fixed;
-            min-width: 160px;
-            background: white;
-            border-radius: 12px;
-            box-shadow: 0 18px 45px -30px rgba(15, 23, 42, 0.5);
-            padding: 0.35rem;
-            opacity: 0;
-            transform: scale(0.96);
-            transition: opacity 0.16s ease, transform 0.16s ease;
-            pointer-events: none;
-            z-index: 1100;
-        }
-
-        .context-menu.show {
-            opacity: 1;
-            transform: scale(1);
-            pointer-events: auto;
-        }
-
-        .context-menu button {
-            width: 100%;
+        .description {
             text-align: left;
-            padding: 0.65rem 0.85rem;
-            border-radius: 9px;
-            background: none;
-            font-size: 0.9rem;
-            color: #1e293b;
+            line-height: 1.9;
+            font-size: 15px;
+            padding: 0 10px;
+            color: #5A4A3D;
         }
 
-        .context-menu button:hover {
-            background: rgba(99, 102, 241, 0.12);
-        }
-
-        .context-menu button.delete {
-            color: #dc2626;
-        }
-
-        .context-menu button.delete:hover {
-            background: rgba(248, 113, 113, 0.16);
-        }
-
-        .confirm-overlay {
-            position: fixed;
-            inset: 0;
-            background: rgba(15, 23, 42, 0.55);
+        .warning-box {
+            border-radius: 24px;
+            padding: 14px 20px;
+            margin: 0 auto;
             display: flex;
             align-items: center;
             justify-content: center;
-            opacity: 0;
-            pointer-events: none;
-            transition: opacity 0.2s ease;
-            z-index: 1300;
+            max-width: 92%;
         }
 
-        .confirm-overlay.show {
-            opacity: 1;
-            pointer-events: auto;
-        }
-
-        .confirm-dialog {
-            background: white;
-            border-radius: 16px;
-            padding: 1.75rem;
-            width: min(360px, calc(100% - 32px));
-            text-align: center;
-            transform: scale(0.93);
-            transition: transform 0.24s ease;
-        }
-
-        .confirm-overlay.show .confirm-dialog {
-            transform: scale(1);
-        }
-
-        .confirm-actions {
+        .warning-icon {
+            margin-right: 14px;
+            flex-shrink: 0;
             display: flex;
+            align-items: center;
             justify-content: center;
-            gap: 0.75rem;
-            margin-top: 1.5rem;
         }
 
-        .warning {
-            margin-top: 1rem;
-            padding: 0.9rem 1rem;
-            background: rgba(251, 191, 36, 0.16);
+        .warning-icon svg {
+            width: 28px;
+            height: 28px;
+        }
+
+        .warning-text {
+            font-size: 15px;
+            font-weight: 600;
+            white-space: nowrap;
+            padding: 6px 12px;
+            border-radius: 8px;
+        }
+
+        .login-card {
+            background: rgba(255, 255, 255, 0.86);
+            border-radius: 28px;
+            padding: 26px 24px 26px;
+            box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
+            display: flex;
+            flex-direction: column;
+            gap: 22px;
+        }
+
+        .login-section,
+        .admin-section {
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+        }
+
+        .login-row {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 18px;
+        }
+
+        .section-title {
+            font-size: 22px;
+            font-weight: 600;
+            letter-spacing: 1px;
+            color: #23150F;
+            white-space: nowrap;
+        }
+
+        .nickname-input,
+        .password-input {
+            background-color: #FFF;
+            border: 2px solid #D4C4B4;
             border-radius: 12px;
-            border: 1px solid rgba(217, 119, 6, 0.35);
-            color: #b45309;
-            font-size: 0.85rem;
+            padding: 13px 20px;
+            font-size: 15px;
+            outline: none;
+            flex: 1;
+            color: #5A4A3D;
+        }
+
+        .nickname-input::placeholder,
+        .password-input::placeholder {
+            color: #B8A89A;
+        }
+
+        .nickname-input.readonly {
+            background-color: rgba(244, 236, 229, 0.7);
+            cursor: default;
+        }
+
+        .admin-buttons {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 8px;
+            grid-auto-rows: minmax(86px, auto);
+        }
+
+        .btn-admin {
+            background-color: #E8D4C4;
+            color: #5A4A3D;
+            border: none;
+            border-radius: 18px;
+            padding: 14px 16px;
+            font-size: 15px;
+            cursor: pointer;
+            transition: all 0.3s;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 86px;
+            text-align: center;
+            line-height: 1.3;
+        }
+
+        .btn-admin:hover {
+            background-color: #D8C4B4;
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+        }
+
+        .btn-admin.selected {
+            background-color: #8B5A3D;
+            color: #FFF;
+            box-shadow: inset 0 2px 4px rgba(0,0,0,0.3);
+            font-weight: 600;
+        }
+
+        .password-input {
+            max-width: 320px;
+            margin: 0 auto;
             display: none;
         }
 
-        .warning.show {
+        .note-text {
+            color: #8B7355;
+            font-size: 13px;
+            text-align: center;
+        }
+
+        .login-status {
+            display: none;
+            text-align: center;
+            font-size: 14px;
+            font-weight: 600;
+            color: #23150F;
+            margin-top: -4px;
+        }
+
+        .version-text {
+            text-align: center;
+            color: #8B7355;
+            font-size: 13px;
+        }
+
+        .rooms-section {
+            position: relative;
+            background: rgba(255, 255, 255, 0.78);
+            border-radius: 24px;
+            padding: 26px 22px 30px;
+            box-shadow: 0 14px 32px rgba(0, 0, 0, 0.08);
+            margin-top: 4px;
+        }
+
+        .rooms-section.hidden {
+            display: none;
+        }
+
+        .rooms-content {
+            position: relative;
+            z-index: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+        }
+
+        .room-header {
+            text-align: center;
+        }
+
+        .room-header h1 {
+            color: #23150F;
+        }
+
+        .welcome-text {
+            display: none;
+        }
+
+        .online-info {
+            display: none;
+            align-items: center;
+            color: #5A4A3D;
+            font-size: 15px;
+            margin-bottom: 18px;
+            padding: 0 5px;
+        }
+
+        .online-dot {
+            width: 11px;
+            height: 11px;
+            background-color: #4CAF50;
+            border-radius: 50%;
+            margin-right: 8px;
+        }
+
+        .rooms-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 14px;
+            grid-auto-rows: minmax(150px, 1fr);
+        }
+
+        .room-item {
+            background-color: #E8CFC4;
+            border-radius: 16px;
+            padding: 20px 16px 18px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: flex-start;
+            gap: 12px;
+            cursor: default;
+            transition: all 0.3s;
+            box-shadow: 0 3px 8px rgba(0,0,0,0.12);
+            position: relative;
+        }
+
+        .room-item:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 6px 16px rgba(0,0,0,0.18);
+        }
+
+        .room-item:active {
+            transform: translateY(-1px);
+            box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+        }
+
+        .room-item.has-users {
+            background-color: #C4E8D4;
+        }
+
+        .room-mice {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            font-weight: 600;
+            color: #5A4A3D;
+        }
+
+        .mouse-icons {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            color: #5A4A3D;
+            min-height: 18px;
+        }
+
+        .mouse-icons svg {
+            width: 18px;
+            height: 18px;
             display: block;
+        }
+
+        .room-item.has-users .mouse-icons {
+            color: #4CAF50;
+        }
+
+        .room-mice-text {
+            font-size: 13px;
+        }
+
+        .room-lamp {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .room-lamp svg {
+            width: 18px;
+            height: 18px;
+            fill: #8B7355;
+        }
+
+        .room-lamp.on svg {
+            fill: #4CAF50;
+            filter: drop-shadow(0 0 6px rgba(76, 175, 80, 0.45));
+        }
+
+        .room-name {
+            color: #23150F;
+            font-size: 16px;
+            text-align: center;
+            font-weight: 700;
+        }
+
+        .room-action {
+            margin-top: auto;
+            background: linear-gradient(135deg, #D8A776 0%, #B87A4B 100%);
+            color: #FFF;
+            border: none;
+            border-radius: 12px;
+            padding: 10px 18px;
+            font-size: 15px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            min-width: 120px;
+        }
+
+        .room-action:hover:not(:disabled) {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 18px rgba(184, 122, 75, 0.35);
+        }
+
+        .room-action:disabled {
+            cursor: not-allowed;
+            opacity: 0.6;
+            box-shadow: none;
+        }
+
+        .room-create {
+            display: flex;
+            gap: 8px;
+            width: 100%;
+            align-items: center;
+        }
+
+        .room-create input {
+            flex: 1;
+            background-color: rgba(107, 90, 61, 0.15);
+            color: #5A4A3D;
+            border: 2px solid rgba(107, 90, 61, 0.3);
+            border-radius: 10px;
+            padding: 11px 14px;
+            font-size: 14px;
+            outline: none;
+        }
+
+        .room-create input::placeholder {
+            color: #B8A89A;
+        }
+
+        .room-create button {
+            background: linear-gradient(135deg, #A57B68 0%, #8C5C4A 100%);
+            color: #FFF;
+            border: none;
+            border-radius: 10px;
+            padding: 10px 16px;
+            font-size: 14px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            white-space: nowrap;
+        }
+
+        .room-create button:hover:not(:disabled) {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 18px rgba(140, 92, 74, 0.35);
+        }
+
+        .room-create button:disabled {
+            cursor: not-allowed;
+            opacity: 0.6;
+            box-shadow: none;
+        }
+
+        .room-item.placeholder {
+            justify-content: space-between;
+        }
+
+        .chat-page {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: #F5F5F5;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .chat-header {
+            background-color: #FFF;
+            padding: 14px 16px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+        }
+
+        .icon-button {
+            background: none;
+            border: none;
+            cursor: pointer;
+            padding: 0;
+            width: 35px;
+            height: 35px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .icon-button svg {
+            width: 26px;
+            height: 26px;
+            fill: #5A4A3D;
+            transition: transform 0.2s ease;
+        }
+
+        .icon-button:hover svg {
+            transform: scale(1.05);
+        }
+
+        .icon-button:focus-visible {
+            outline: 2px solid rgba(90, 74, 61, 0.6);
+            outline-offset: 2px;
+        }
+
+        .chat-header-center {
+            flex: 1;
+            text-align: center;
+        }
+
+        .room-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: #5A4A3D;
+            margin-bottom: 3px;
+        }
+
+        .online-count {
+            font-size: 13px;
+            color: #8B7355;
+        }
+
+        .chat-header-right {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            justify-content: flex-end;
+        }
+
+        .timer-badge {
+            background-color: #FFB347;
+            color: #5A4A3D;
+            padding: 3px 9px;
+            border-radius: 10px;
+            font-size: 11px;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .messages-container {
+            flex: 1;
+            overflow-y: auto;
+            padding: 18px;
+            padding-bottom: 100px;
+        }
+
+        .notice-box {
+            background-color: #FFF;
+            border-radius: 10px;
+            padding: 14px;
+            margin-bottom: 18px;
+            color: #5A4A3D;
+            font-size: 13px;
+            line-height: 1.7;
+        }
+
+        .notice-box p {
+            margin: 6px 0;
+        }
+
+        .message-item {
+            display: flex;
+            flex-direction: column;
+            margin-bottom: 14px;
+        }
+
+        .message-item.mine {
+            align-items: flex-end;
+        }
+
+        .message-nickname {
+            font-size: 12px;
+            color: #8B7355;
+            margin-bottom: 3px;
+            padding: 0 6px;
+        }
+
+        .admin-icon {
+            display: inline-flex;
+            align-items: center;
+            margin-left: 6px;
+        }
+
+        .admin-icon svg {
+            width: 14px;
+            height: 14px;
+            fill: currentColor;
+        }
+
+        .message-bubble {
+            max-width: 70%;
+            padding: 11px 14px;
+            border-radius: 14px;
+            word-wrap: break-word;
+            animation: slideIn 0.3s ease-out;
+        }
+
+        .message-bubble.mine {
+            background-color: #A8D5BA;
+        }
+
+        .message-bubble.others {
+            background-color: #F0E6D6;
+        }
+
+        @keyframes slideIn {
+            from {
+                opacity: 0;
+                transform: translateY(8px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        .chat-input-container {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            background-color: #FFF;
+            padding: 14px 16px;
+            border-top: 1px solid #E0E0E0;
+        }
+
+        .chat-input-row {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+        }
+
+        .message-input {
+            flex: 1;
+            background-color: #F5F5F5;
+            border: 2px solid #E0E0E0;
+            border-radius: 22px;
+            padding: 11px 18px;
+            font-size: 15px;
+            color: #333;
+            outline: none;
+        }
+
+        .btn-send {
+            background-color: #6B5A3D;
+            color: #E8DCC4;
+            border: none;
+            border-radius: 10px;
+            padding: 11px 22px;
+            font-size: 15px;
+            font-weight: 500;
+            cursor: pointer;
+            white-space: nowrap;
+            flex-shrink: 0;
+        }
+
+        .modal {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.9);
+            z-index: 1000;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .modal.show {
+            display: flex;
+        }
+
+        .admin-actions {
+            display: none;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .admin-action-btn {
+            background-color: #6B5A3D;
+            color: #E8DCC4;
+            border: none;
+            border-radius: 8px;
+            padding: 6px 12px;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background-color 0.2s ease;
+        }
+
+        .admin-action-btn:hover {
+            background-color: #544730;
+        }
+
+        .entry-notice {
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+
+        .menu-modal .modal-content {
+            background-color: #FFF;
+            border-radius: 14px;
+            padding: 28px;
+            max-width: 380px;
+            width: 90%;
+        }
+
+        .menu-title {
+            font-size: 22px;
+            font-weight: 600;
+            color: #5A4A3D;
+            margin-bottom: 20px;
+            text-align: center;
+        }
+
+        .menu-btn {
+            background-color: #6B5A3D;
+            color: #E8DCC4;
+            border: none;
+            border-radius: 10px;
+            padding: 12px;
+            font-size: 15px;
+            font-weight: 500;
+            cursor: pointer;
+            width: 100%;
+            margin-bottom: 10px;
+            transition: all 0.3s;
+        }
+
+        .menu-btn:hover {
+            background-color: #544730;
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding-top: 32px;
+            }
+
+            h1 {
+                font-size: 34px;
+            }
+
+            h2 {
+                font-size: 22px;
+            }
+
+            .description {
+                font-size: 14px;
+            }
+
+            .login-row {
+                flex-direction: column;
+                gap: 12px;
+            }
+
+            .section-title {
+                width: 100%;
+                text-align: center;
+            }
+
+            .nickname-input {
+                width: 100%;
+            }
+
+            .login-card {
+                padding: 22px 18px 24px;
+                gap: 18px;
+            }
+
+            .admin-buttons {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .rooms-grid {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .rooms-section {
+                padding: 22px 18px 26px;
+                border-radius: 20px;
+            }
+
+            .rooms-content {
+                gap: 16px;
+            }
+
+            .rooms-content h1 {
+                font-size: 28px !important;
+            }
+
+            .room-item {
+                min-height: 140px;
+            }
+        }
+
+        @media (max-width: 540px) {
+            .headline-row {
+                flex-direction: column;
+                gap: 10px;
+            }
+
+            .room-create {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .room-create button {
+                width: 100%;
+            }
         }
     </style>
 </head>
 <body>
-    <main class="panel">
-        <h1>📸 我的圖片庫（儲存層修正版）</h1>
-        <p>這份範例展示了如何在 Canva Code 的沙箱環境中可靠地儲存、讀取並刪除圖片。重點調整包含：
-            <strong>自動偵測可用儲存層</strong>、<strong>在 fallback 時同步清除舊資料</strong> 以及
-            <strong>避免被遮罩擋住的自訂確認視窗</strong>。</p>
-
-        <section class="input-row">
-            <label for="imageInput">選擇圖片</label>
-            <input id="imageInput" type="file" accept="image/*" multiple />
-        </section>
-
-        <section class="input-row">
-            <label for="imageName">圖片名稱（可選）</label>
-            <input id="imageName" type="text" placeholder="輸入圖片說明" />
-        </section>
-
-        <div class="actions">
-            <button id="pickImage" class="primary">上傳圖片</button>
-            <button id="clearAll" class="secondary">清除所有圖片</button>
+    <div id="mainContainer" class="container">
+        <div class="headline">
+            <h1>花枝鼠社群專用</h1>
+            <div class="headline-row">
+                <h2>臨時私密對話小工具</h2>
+                <div class="lobby-indicator" id="lobbyIndicator">
+                    <span class="lobby-lamp" id="lobbyLamp" aria-hidden="true">
+                        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                            <circle cx="8" cy="8" r="6" />
+                        </svg>
+                    </span>
+                    <span class="lobby-status-text" id="lobbyStatusText" aria-live="polite">大廳沒有老鼠</span>
+                </div>
+            </div>
         </div>
 
-        <div class="storage-info" id="storageInfo">正在讀取儲存空間...</div>
-        <div class="warning" id="memoryWarning">⚠️ 因瀏覽器儲存空間不足，目前資料僅暫存於記憶體，重新整理後會消失。</div>
+        <div class="description">
+            <p>有時候想跟群友單獨說兩句，但是又不方便留Line怎麼辦？</p>
+            <p>真的有人喜歡Line 好友名單保持整潔啊🥲</p>
+            <p>現在社群提供成員一個不用換 Line 也能講悄悄話的地方。</p>
+        </div>
 
-        <section class="gallery" id="imageGallery"></section>
-    </main>
+        <div class="warning-box" id="warningBox">
+            <div class="warning-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                    <path fill="currentColor" d="M12 2.5a1.5 1.5 0 0 1 1.32.83l8.16 15.38A1.5 1.5 0 0 1 20.16 21H3.84a1.5 1.5 0 0 1-1.32-2.29l8.16-15.38A1.5 1.5 0 0 1 12 2.5zm0 2.22L4.53 19.5h14.94L12 4.72zm-.01 4.03c.52 0 .94.42.94.94v4.28a.94.94 0 1 1-1.88 0v-4.28c0-.52.42-.94.94-.94zm0 7.14a1.1 1.1 0 1 1 0 2.2 1.1 1.1 0 0 1 0-2.2z"/>
+                </svg>
+            </div>
+            <div class="warning-text" id="warningText">提高警覺、嚴防詐騙、勿提供個資/轉帳</div>
+        </div>
 
-    <div class="context-menu" id="contextMenu">
-        <button id="btnCopy">📋 複製連結</button>
-        <button id="btnDelete" class="delete">🗑️ 刪除此圖片</button>
+        <div class="login-card">
+            <div class="login-section">
+                <div class="login-row">
+                    <div class="section-title">一般成員</div>
+                    <input type="text" id="nicknameInput" class="nickname-input" placeholder="輸入暱稱">
+                </div>
+            </div>
+
+            <div class="admin-section">
+                <div class="section-title" style="text-align: center;">管理員</div>
+                <div class="admin-buttons">
+                    <button onclick="selectAdmin(event, '吸鼠女')" class="btn-admin" data-admin="吸鼠女">吸鼠女</button>
+                    <button onclick="selectAdmin(event, '大白美妙')" class="btn-admin" data-admin="大白美妙">大白美妙</button>
+                    <button onclick="selectAdmin(event, '采瑄')" class="btn-admin" data-admin="采瑄">采瑄</button>
+                    <button onclick="selectAdmin(event, 'Jinx')" class="btn-admin" data-admin="Jinx">Jinx</button>
+                    <button onclick="selectAdmin(event, '芒果')" class="btn-admin" data-admin="芒果">芒果</button>
+                </div>
+                <input type="password" id="adminPassword" class="password-input" placeholder="輸入密碼">
+                <div id="loginStatus" class="login-status" aria-live="polite"></div>
+            </div>
+
+            <div id="roomsSection" class="rooms-section disabled">
+                <div class="rooms-content">
+                    <div class="room-header">
+                        <h1 style="font-size: 34px; margin-bottom: 6px;">選擇鼠窩</h1>
+                        <div class="welcome-text">歡迎 <strong id="welcomeName"></strong></div>
+                    </div>
+
+                    <div class="rooms-grid" id="roomsList">
+                        <div class="room-item" data-room="溫溫鼠窩">
+                            <div class="room-mice">
+                                <span class="room-lamp" aria-hidden="true">
+                                    <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                                        <circle cx="8" cy="8" r="6" />
+                                    </svg>
+                                </span>
+                                <div class="mouse-icons" aria-hidden="true"></div>
+                                <span class="room-mice-text">0 隻老鼠</span>
+                            </div>
+                            <div class="room-name">溫溫鼠窩</div>
+                            <button type="button" class="room-action" data-room="溫溫鼠窩">加入</button>
+                        </div>
+                        <div class="room-item placeholder" data-room="empty1" data-slot="1">
+                            <div class="room-mice">
+                                <span class="room-lamp" aria-hidden="true">
+                                    <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                                        <circle cx="8" cy="8" r="6" />
+                                    </svg>
+                                </span>
+                                <div class="mouse-icons" aria-hidden="true"></div>
+                                <span class="room-mice-text">0 隻老鼠</span>
+                            </div>
+                            <div class="room-name">鼠窩沒鼠</div>
+                            <div class="room-create">
+                                <input type="text" id="roomSlotInput1" data-slot="1" placeholder="輸入鼠窩名稱..." disabled>
+                                <button type="button" class="room-create-btn" data-slot="1" disabled>創建鼠窩</button>
+                            </div>
+                            <button type="button" class="room-action" data-room="" style="display: none;" disabled>加入</button>
+                        </div>
+                        <div class="room-item placeholder" data-room="empty2" data-slot="2">
+                            <div class="room-mice">
+                                <span class="room-lamp" aria-hidden="true">
+                                    <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                                        <circle cx="8" cy="8" r="6" />
+                                    </svg>
+                                </span>
+                                <div class="mouse-icons" aria-hidden="true"></div>
+                                <span class="room-mice-text">0 隻老鼠</span>
+                            </div>
+                            <div class="room-name">鼠窩沒鼠</div>
+                            <div class="room-create">
+                                <input type="text" id="roomSlotInput2" data-slot="2" placeholder="輸入鼠窩名稱..." disabled>
+                                <button type="button" class="room-create-btn" data-slot="2" disabled>創建鼠窩</button>
+                            </div>
+                            <button type="button" class="room-action" data-room="" style="display: none;" disabled>加入</button>
+                        </div>
+                        <div class="room-item placeholder" data-room="empty3" data-slot="3">
+                            <div class="room-mice">
+                                <span class="room-lamp" aria-hidden="true">
+                                    <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                                        <circle cx="8" cy="8" r="6" />
+                                    </svg>
+                                </span>
+                                <div class="mouse-icons" aria-hidden="true"></div>
+                                <span class="room-mice-text">0 隻老鼠</span>
+                            </div>
+                            <div class="room-name">鼠窩沒鼠</div>
+                            <div class="room-create">
+                                <input type="text" id="roomSlotInput3" data-slot="3" placeholder="輸入鼠窩名稱..." disabled>
+                                <button type="button" class="room-create-btn" data-slot="3" disabled>創建鼠窩</button>
+                            </div>
+                            <button type="button" class="room-action" data-room="" style="display: none;" disabled>加入</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="version-text">2025/10/03 創建 v1.3.1</div>
     </div>
 
-    <div class="confirm-overlay" id="confirmOverlay" role="dialog" aria-modal="true">
-        <div class="confirm-dialog">
-            <div style="font-size:2.4rem;">🗑️</div>
-            <h2 style="margin:1rem 0 0.25rem;">確定要刪除這張圖片嗎？</h2>
-            <p style="color:#64748b; font-size:0.9rem;">刪除後無法復原，且將立即從儲存空間移除。</p>
-            <div class="confirm-actions">
-                <button class="secondary" id="cancelDelete">取消</button>
-                <button class="primary" id="confirmDelete">刪除</button>
+    <div id="chatPage" class="chat-page">
+        <div class="chat-header">
+            <button class="btn-back icon-button" onclick="backToRooms()" aria-label="返回房間列表">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                    <path fill="currentColor" d="M15.53 4.47a.75.75 0 0 1 0 1.06L9.06 12l6.47 6.47a.75.75 0 0 1-1.06 1.06l-7-7a.75.75 0 0 1 0-1.06l7-7a.75.75 0 0 1 1.06 0z"/>
+                </svg>
+            </button>
+            <div class="chat-header-center">
+                <div class="room-title" id="currentRoomName"></div>
+                <div class="online-count">在線：<span id="roomOnlineCount">0</span>/5</div>
+            </div>
+            <div class="chat-header-right">
+                <span class="timer-badge" id="messageTimer" style="display: none;"></span>
+                <div class="admin-actions" id="adminActions">
+                    <button type="button" class="admin-action-btn" id="clearChatBtn" onclick="clearChat()">清空對話</button>
+                    <button type="button" class="admin-action-btn" id="statsBtn" onclick="showStats()">統計人次</button>
+                </div>
+                <button class="btn-menu icon-button" onclick="showMenu()" aria-label="開啟選單">
+                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                        <path fill="currentColor" d="M12 5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm0 8a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm0 8a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"/>
+                    </svg>
+                </button>
+            </div>
+        </div>
+
+        <div class="messages-container" id="messagesContainer">
+            <div class="notice-box">
+                <p id="entryNotice" class="entry-notice"></p>
+                <p><strong>提醒：</strong>訊息會在發送 1 小時後自動清除</p>
+                <p>文字與圖示僅提供臨時交流，請勿外傳</p>
+                <p>傳訊禮貌請維持，請勿於此進行金錢往來</p>
+                <p>當所有成員離開此聊天室時，系統會自動清空對話記錄</p>
+                <p style="margin-top: 10px;"><strong>最後提醒：</strong></p>
+                <p>1. 請勿在此向他人借錢</p>
+                <p>2. 請勿在此借錢給他人</p>
+                <p>3. 請勿在此講我壞話</p>
+            </div>
+            <div id="messagesList"></div>
+        </div>
+
+        <div class="chat-input-container">
+            <div class="chat-input-row">
+                <input type="text" id="messageInput" class="message-input" placeholder="輸入訊息..." onkeypress="handleKeyPress(event)">
+                <button class="btn-send" onclick="sendMessage()">發送</button>
             </div>
         </div>
     </div>
 
-    <div class="toast" id="toast"></div>
+    <div id="menuModal" class="modal menu-modal" onclick="closeMenu()">
+        <div class="modal-content" onclick="event.stopPropagation()">
+            <div class="menu-title">選單</div>
+            <button onclick="logout()" class="menu-btn">登出</button>
+        </div>
+    </div>
 
-    <script>
-        const $ = (selector) => document.querySelector(selector);
-        const $$ = (selector) => Array.from(document.querySelectorAll(selector));
+    <script type="module">
+        let currentUser = null;
+        let currentRoom = null;
+        let selectedAdmin = null;
+        let countdownInterval = null;
+        let cleanupInterval = null;
+        let messageExpiryTimestamp = null;
+        let messagesListener = null;
+        let onlineListener = null;
+        let allRoomsListener = null;
+        let userPresenceRef = null;
+        let pagePresenceRef = null;
+        let roomsInitialized = false;
+        let lobbyListener = null;
+        let visitRecorded = false;
+        let latestRoomsData = {};
+        let isLobbyPresenceActive = false;
 
-        const KEY = "imageGallery";
-
-        const imgStore = (() => {
-            const DRIVER_KEY = `${KEY}::driver`;
-            let memoryCache = [];
-            let currentDriver = null;
-
-            const safeSession = {
-                get(key) {
-                    try {
-                        return sessionStorage.getItem(key);
-                    } catch (error) {
-                        console.warn("sessionStorage get 失敗：", error);
-                        return null;
-                    }
-                },
-                set(key, value) {
-                    try {
-                        sessionStorage.setItem(key, value);
-                    } catch (error) {
-                        console.warn("sessionStorage set 失敗：", error);
-                    }
-                },
-                remove(key) {
-                    try {
-                        sessionStorage.removeItem(key);
-                    } catch (error) {
-                        console.warn("sessionStorage remove 失敗：", error);
-                    }
-                }
-            };
-
-            const drivers = {
-                local: {
-                    read() {
-                        const raw = localStorage.getItem(KEY);
-                        if (!raw) return [];
-                        return JSON.parse(raw);
-                    },
-                    write(payload) {
-                        localStorage.setItem(KEY, payload);
-                    },
-                    clear() {
-                        localStorage.removeItem(KEY);
-                    }
-                },
-                session: {
-                    read() {
-                        const raw = sessionStorage.getItem(KEY);
-                        if (!raw) return [];
-                        return JSON.parse(raw);
-                    },
-                    write(payload) {
-                        sessionStorage.setItem(KEY, payload);
-                    },
-                    clear() {
-                        sessionStorage.removeItem(KEY);
-                    }
-                },
-                memory: {
-                    read() {
-                        return memoryCache;
-                    },
-                    write(data) {
-                        memoryCache = data;
-                    },
-                    clear() {
-                        memoryCache = [];
-                    }
-                }
-            };
-
-            const setDriver = (name) => {
-                currentDriver = name;
-                safeSession.set(DRIVER_KEY, name);
-            };
-
-            const getDriverFromSession = () => safeSession.get(DRIVER_KEY);
-
-            const getDriver = () => currentDriver || getDriverFromSession() || "memory";
-
-            const tryRead = (driverName) => {
-                const driver = drivers[driverName];
-                if (!driver) return null;
-                try {
-                    const data = driver.read();
-                    if (!Array.isArray(data)) return [];
-                    if (driverName !== "memory") {
-                        drivers.memory.write(data);
-                    }
-                    setDriver(driverName);
-                    return data;
-                } catch (error) {
-                    console.warn(`讀取 ${driverName} 失敗：`, error);
-                    try {
-                        driver.clear && driver.clear();
-                    } catch (clearError) {
-                        console.warn(`清除 ${driverName} 失敗：`, clearError);
-                    }
-                    return null;
-                }
-            };
-
-            const read = () => {
-                const preferred = getDriver();
-                const order = Array.from(new Set([preferred, "local", "session", "memory"]));
-                for (const driverName of order) {
-                    const data = tryRead(driverName);
-                    if (Array.isArray(data)) {
-                        return data;
-                    }
-                }
-                drivers.memory.clear();
-                setDriver("memory");
-                return [];
-            };
-
-            const write = (data) => {
-                const payload = JSON.stringify(data);
-                for (const driverName of ["local", "session"]) {
-                    const driver = drivers[driverName];
-                    if (!driver) continue;
-                    try {
-                        driver.write(payload);
-                        drivers.memory.write(data);
-                        setDriver(driverName);
-                        return driverName;
-                    } catch (error) {
-                        console.warn(`寫入 ${driverName} 失敗：`, error);
-                        try {
-                            driver.clear && driver.clear();
-                        } catch (clearError) {
-                            console.warn(`清除 ${driverName} 失敗：`, clearError);
-                        }
-                    }
-                }
-                drivers.memory.write(data);
-                setDriver("memory");
-                return "memory";
-            };
-
-            return {
-                read,
-                write,
-                getDriver
-            };
-        })();
-
-        let images = imgStore.read().map((item) => ({
-            ...item,
-            id: String(item.id || crypto.randomUUID())
-        }));
-
-        const toast = $("#toast");
-        let toastTimer = null;
-
-        const showToast = (message, duration = 1600) => {
-            toast.textContent = message;
-            toast.classList.add("show");
-            if (toastTimer) window.clearTimeout(toastTimer);
-            toastTimer = window.setTimeout(() => {
-                toast.classList.remove("show");
-            }, duration);
+        const adminPasswords = {
+            '吸鼠女': '444',
+            '采瑄': '151',
+            '芒果': 'Ying',
+            '大白美妙': 'totoro',
+            'Jinx': 'jinx'
         };
 
-        const updateStorageInfo = (overrideDriver = null) => {
-            const storageInfo = $("#storageInfo");
-            const warning = $("#memoryWarning");
-            if (!storageInfo) return;
+        const lobbySessionId = `lobby_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
 
-            const driver = overrideDriver || imgStore.getDriver();
-            const dataSize = JSON.stringify(images).length;
-            const sizeMB = (dataSize / 1024 / 1024).toFixed(2);
+        const morandiSchemes = [
+            { bg: '#4B3A41', text: '#F7F1EA' },
+            { bg: '#3F4856', text: '#F4EFE9' },
+            { bg: '#4A4F46', text: '#F6F1EB' },
+            { bg: '#4C3F4F', text: '#F5EFE7' },
+            { bg: '#3D4D4F', text: '#F3EDE6' },
+            { bg: '#4F433D', text: '#F6F0E9' }
+        ];
 
-            const driverLabel = {
-                local: "localStorage",
-                session: "sessionStorage",
-                memory: "記憶體（暫存）"
-            }[driver] || driver;
+        const warningStyles = [
+            { bg: '#FF0000', color: '#FFFFFF' },
+            { bg: '#000000', color: '#FFFF00' },
+            { bg: '#000000', color: '#FFFFFF' }
+        ];
 
-            storageInfo.textContent = `已使用：${sizeMB} MB / ~5 MB（目前使用：${driverLabel}）`;
-            storageInfo.style.color = dataSize > 4 * 1024 * 1024 ? "#dc2626" : "#475569";
+        const SVG_NS = 'http://www.w3.org/2000/svg';
 
-            if (driver === "memory") {
-                warning.classList.add("show");
-            } else {
-                warning.classList.remove("show");
-            }
-        };
-
-        const saveImages = () => {
-            const driver = imgStore.write(images);
-            updateStorageInfo(driver);
-            return driver;
-        };
-
-        const renderGallery = () => {
-            const gallery = $("#imageGallery");
-            if (!gallery) return;
-            if (!images.length) {
-                gallery.innerHTML = `<div style="padding:2.5rem 1rem; text-align:center; color:#94a3b8; background:#f8fafc; border-radius:14px;">目前沒有任何圖片，請先上傳。</div>`;
+        async function initializeLobbyPresence() {
+            if (!window.firebaseDB || isLobbyPresenceActive) {
                 return;
             }
 
-            gallery.innerHTML = images
-                .map((img) => {
-                    const title = img.name || "未命名圖片";
-                    return `
-                    <article class="card" data-id="${img.id}">
-                        <img src="${img.data}" alt="${title}" />
-                        <div class="caption">${title}</div>
-                        <div class="overlay">長按或右鍵可複製／刪除</div>
-                    </article>
-                `;
-                })
-                .join("");
-        };
+            try {
+                pagePresenceRef = window.firebaseRef(window.firebaseDB, `pageOnline/${lobbySessionId}`);
+                await window.firebaseSet(pagePresenceRef, {
+                    nickname: '訪客',
+                    isAdmin: false,
+                    timestamp: Date.now()
+                });
+                window.firebaseOnDisconnect(pagePresenceRef).remove();
+                isLobbyPresenceActive = true;
+            } catch (error) {
+                console.warn('無法建立大廳狀態', error);
+            }
+        }
 
-        const pickImageButton = $("#pickImage");
-        const imageInput = $("#imageInput");
+        async function updateLobbyPresence() {
+            if (!window.firebaseDB) {
+                return;
+            }
 
-        pickImageButton?.addEventListener("click", () => imageInput?.click());
+            if (!pagePresenceRef) {
+                await initializeLobbyPresence();
+            }
 
-        const compressImage = (file, maxWidth = 1600, quality = 0.8) => {
-            return new Promise((resolve, reject) => {
-                const img = new Image();
-                const reader = new FileReader();
-                reader.onload = (event) => {
-                    img.onload = () => {
-                        let { width, height } = img;
-                        if (width > maxWidth) {
-                            height = Math.round((height * maxWidth) / width);
-                            width = maxWidth;
-                        }
-                        const canvas = document.createElement("canvas");
-                        canvas.width = width;
-                        canvas.height = height;
-                        const ctx = canvas.getContext("2d");
-                        ctx.drawImage(img, 0, 0, width, height);
-                        resolve(canvas.toDataURL("image/jpeg", quality));
-                    };
-                    img.onerror = reject;
-                    img.src = event.target.result;
-                };
-                reader.onerror = reject;
-                reader.readAsDataURL(file);
-            });
-        };
+            if (!pagePresenceRef) {
+                return;
+            }
 
-        const handleFiles = async (fileList) => {
-            for (const file of Array.from(fileList)) {
-                if (!file.type.startsWith("image/")) continue;
-                try {
-                    const compressed = await compressImage(file);
-                    const id = crypto.randomUUID();
-                    const name = $("#imageName").value.trim() || file.name;
-                    images.push({
-                        id,
-                        name,
-                        data: compressed,
-                        type: "image/jpeg",
-                        originalSize: file.size,
-                        uploadDate: new Date().toISOString()
-                    });
-                    saveImages();
-                    renderGallery();
-                    showToast("✅ 圖片已新增並儲存");
-                    $("#imageName").value = "";
-                } catch (error) {
-                    console.error("圖片處理失敗：", error);
-                    showToast("❌ 圖片處理失敗，請重試", 2200);
+            const payload = currentUser ? {
+                nickname: currentUser.nickname,
+                isAdmin: currentUser.isAdmin,
+                timestamp: Date.now()
+            } : {
+                nickname: '訪客',
+                isAdmin: false,
+                timestamp: Date.now()
+            };
+
+            try {
+                await window.firebaseSet(pagePresenceRef, payload);
+            } catch (error) {
+                console.warn('更新大廳狀態失敗', error);
+            }
+        }
+
+        function createCrownIcon() {
+            const svg = document.createElementNS(SVG_NS, 'svg');
+            svg.setAttribute('viewBox', '0 0 24 24');
+            svg.setAttribute('aria-hidden', 'true');
+            svg.setAttribute('focusable', 'false');
+            const path = document.createElementNS(SVG_NS, 'path');
+            path.setAttribute('d', 'M4 7.5l3.5 3 2.5-4 2.5 4 3.5-3 4 6.5v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-5l0-0.02L4 7.5zm2 10.5h12v-3.93l-2.79-4.54-2.83 2.42-2.38-3.8-2.38 3.8-2.83-2.42L6 14.07V18z');
+            path.setAttribute('fill', 'currentColor');
+            svg.appendChild(path);
+            return svg;
+        }
+
+        function createMouseIcon() {
+            const svg = document.createElementNS(SVG_NS, 'svg');
+            svg.setAttribute('viewBox', '0 0 24 24');
+            svg.setAttribute('aria-hidden', 'true');
+            svg.setAttribute('focusable', 'false');
+
+            const tail = document.createElementNS(SVG_NS, 'path');
+            tail.setAttribute('d', 'M17 14c2.2 1 3.5 2.4 3.5 4 0 1.1-.7 1.9-1.8 1.9-1 0-1.6-.6-1.6-1.4');
+            tail.setAttribute('fill', 'none');
+            tail.setAttribute('stroke', 'currentColor');
+            tail.setAttribute('stroke-width', '1.4');
+            tail.setAttribute('stroke-linecap', 'round');
+            tail.setAttribute('stroke-linejoin', 'round');
+
+            const body = document.createElementNS(SVG_NS, 'ellipse');
+            body.setAttribute('cx', '12');
+            body.setAttribute('cy', '14');
+            body.setAttribute('rx', '7');
+            body.setAttribute('ry', '6');
+            body.setAttribute('fill', 'currentColor');
+
+            const earLeft = document.createElementNS(SVG_NS, 'circle');
+            earLeft.setAttribute('cx', '8.2');
+            earLeft.setAttribute('cy', '9');
+            earLeft.setAttribute('r', '2.4');
+            earLeft.setAttribute('fill', 'currentColor');
+
+            const earRight = document.createElementNS(SVG_NS, 'circle');
+            earRight.setAttribute('cx', '15.8');
+            earRight.setAttribute('cy', '9');
+            earRight.setAttribute('r', '2.4');
+            earRight.setAttribute('fill', 'currentColor');
+
+            const nose = document.createElementNS(SVG_NS, 'circle');
+            nose.setAttribute('cx', '19');
+            nose.setAttribute('cy', '13');
+            nose.setAttribute('r', '1.1');
+            nose.setAttribute('fill', 'currentColor');
+
+            svg.appendChild(tail);
+            svg.appendChild(earLeft);
+            svg.appendChild(earRight);
+            svg.appendChild(body);
+            svg.appendChild(nose);
+            return svg;
+        }
+
+        const randomScheme = morandiSchemes[Math.floor(Math.random() * morandiSchemes.length)];
+        const randomWarning = warningStyles[Math.floor(Math.random() * warningStyles.length)];
+
+        document.body.style.backgroundColor = randomScheme.bg;
+
+        document.querySelectorAll('h1, h2, .description, .description p, .version-text').forEach(el => {
+            el.style.color = randomScheme.text;
+        });
+
+        const warningText = document.getElementById('warningText');
+        warningText.style.backgroundColor = randomWarning.bg;
+        warningText.style.color = randomWarning.color;
+
+        setRoomControlsEnabled(false);
+        initializeLobbyPresence();
+        listenToLobbyPresence();
+        listenToAllRooms();
+
+        function updateLoginStatus() {
+            const statusEl = document.getElementById('loginStatus');
+            if (!statusEl) return;
+
+            if (currentUser && currentUser.isAdmin) {
+                statusEl.textContent = `登入身分：管理員（${currentUser.nickname}）`;
+                statusEl.style.display = 'block';
+            } else {
+                statusEl.textContent = '';
+                statusEl.style.display = 'none';
+            }
+        }
+
+        function setRoomControlsEnabled(enabled) {
+            const roomsSection = document.getElementById('roomsSection');
+            if (roomsSection) {
+                roomsSection.classList.toggle('disabled', !enabled);
+            }
+
+            document.querySelectorAll('.room-create input').forEach(input => {
+                input.disabled = !enabled;
+                if (!enabled) {
+                    input.value = '';
                 }
+            });
+
+            document.querySelectorAll('.room-create button').forEach(btn => {
+                btn.disabled = !enabled;
+            });
+
+            document.querySelectorAll('.room-action').forEach(btn => {
+                const hasRoom = btn.dataset.room && btn.dataset.room !== '';
+                const isFull = btn.dataset.full === '1';
+                btn.disabled = !hasRoom || isFull;
+            });
+
+            if (latestRoomsData && Object.keys(latestRoomsData).length > 0) {
+                updateRoomsList(latestRoomsData);
+            }
+        }
+
+        function ensureUserProfile() {
+            if (currentUser) {
+                return true;
+            }
+
+            const nicknameInput = document.getElementById('nicknameInput');
+            const passwordInput = document.getElementById('adminPassword');
+            const nickname = nicknameInput.value.trim();
+            const password = passwordInput.value;
+
+            if (selectedAdmin) {
+                if (!password) {
+                    alert('請輸入暱稱或選擇身分並填入密碼');
+                    return false;
+                }
+
+                if (password !== adminPasswords[selectedAdmin]) {
+                    alert('密碼錯誤');
+                    return false;
+                }
+
+                currentUser = {
+                    id: 'admin_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9),
+                    nickname: selectedAdmin,
+                    isAdmin: true
+                };
+            } else {
+                if (!nickname) {
+                    alert('請輸入暱稱或選擇身分並填入密碼');
+                    return false;
+                }
+
+                currentUser = {
+                    id: 'user_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9),
+                    nickname: nickname,
+                    isAdmin: false
+                };
+            }
+
+            nicknameInput.value = currentUser.nickname;
+            nicknameInput.setAttribute('readonly', 'true');
+            nicknameInput.classList.add('readonly');
+
+            passwordInput.style.display = 'none';
+            passwordInput.value = '';
+
+            document.querySelectorAll('.btn-admin').forEach(btn => btn.classList.remove('selected'));
+            selectedAdmin = null;
+
+            updateLobbyPresence();
+            updateLoginStatus();
+            return true;
+        }
+
+        async function showRoomsSection() {
+            const roomsSection = document.getElementById('roomsSection');
+            const mainContainer = document.getElementById('mainContainer');
+
+            roomsSection.classList.remove('hidden');
+            document.body.classList.add('logged-in');
+            mainContainer.classList.add('rooms-visible');
+            document.getElementById('welcomeName').textContent = currentUser.nickname;
+
+            setRoomControlsEnabled(true);
+
+            if (!roomsInitialized) {
+                listenToAllRooms();
+                roomsInitialized = true;
+            }
+
+            if (window.firebaseDB) {
+                await updateLobbyPresence();
+                await recordVisit();
+            }
+
+            roomsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+
+        async function attemptLogin() {
+            if (currentUser) {
+                return;
+            }
+
+            if (!ensureUserProfile()) {
+                return;
+            }
+
+            await showRoomsSection();
+        }
+
+        window.selectAdmin = function(event, adminName) {
+            if (currentUser) {
+                return;
+            }
+
+            document.querySelectorAll('.btn-admin').forEach(btn => {
+                btn.classList.remove('selected');
+            });
+
+            event.target.classList.add('selected');
+            selectedAdmin = adminName;
+            const passwordInput = document.getElementById('adminPassword');
+            passwordInput.style.display = 'block';
+            passwordInput.focus();
+        };
+
+        document.addEventListener('click', function(event) {
+            if (currentUser) {
+                return;
+            }
+
+            const isAdminButton = event.target.classList.contains('btn-admin');
+            const isPasswordInput = event.target.id === 'adminPassword';
+
+            if (!isAdminButton && !isPasswordInput) {
+                document.querySelectorAll('.btn-admin').forEach(btn => {
+                    btn.classList.remove('selected');
+                });
+                selectedAdmin = null;
+                const passwordInput = document.getElementById('adminPassword');
+                passwordInput.style.display = 'none';
+                passwordInput.value = '';
+            }
+        });
+
+        document.getElementById('nicknameInput').addEventListener('keydown', (event) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                attemptLogin();
+            }
+        });
+
+        document.getElementById('adminPassword').addEventListener('keydown', (event) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                attemptLogin();
+            }
+        });
+
+        document.querySelectorAll('.room-create-btn').forEach(button => {
+            button.addEventListener('click', () => {
+                const slot = button.getAttribute('data-slot');
+                window.createRoomFromSlot(slot);
+            });
+        });
+
+        function listenToAllRooms() {
+            if (!window.firebaseDB) return;
+
+            const roomsRef = window.firebaseRef(window.firebaseDB, 'rooms');
+
+            if (allRoomsListener) {
+                allRoomsListener();
+            }
+
+            allRoomsListener = window.firebaseOnValue(roomsRef, (snapshot) => {
+                const roomsData = snapshot.val() || {};
+                updateRoomsList(roomsData);
+            });
+        }
+
+        function updateRoomsList(roomsData) {
+            latestRoomsData = roomsData || {};
+
+            const customRooms = Object.keys(latestRoomsData).filter(roomName => roomName !== '溫溫鼠窩');
+
+            const defaultRoomElement = document.querySelector('#roomsList [data-room="溫溫鼠窩"]');
+            if (defaultRoomElement) {
+                const defaultRoomData = latestRoomsData['溫溫鼠窩'] || {};
+                const defaultOnline = defaultRoomData.online ? Object.keys(defaultRoomData.online).length : 0;
+                updateRoomElement(defaultRoomElement, '溫溫鼠窩', defaultOnline, false);
+            }
+
+            const slotElements = Array.from(document.querySelectorAll('#roomsList [data-slot]'));
+            slotElements.forEach((slot, index) => {
+                const slotNumber = slot.getAttribute('data-slot') || String(index + 1);
+                const roomName = customRooms[index];
+
+                if (roomName) {
+                    const roomData = latestRoomsData[roomName] || {};
+                    const onlineCount = roomData.online ? Object.keys(roomData.online).length : 0;
+                    slot.classList.remove('placeholder');
+                    slot.setAttribute('data-room', roomName);
+                    updateRoomElement(slot, roomName, onlineCount, false);
+                } else {
+                    slot.classList.add('placeholder');
+                    slot.setAttribute('data-room', `empty${slotNumber}`);
+                    const input = slot.querySelector('input[data-slot]');
+                    if (input) {
+                        input.value = '';
+                    }
+                    updateRoomElement(slot, '鼠窩沒鼠', 0, true, slotNumber);
+                }
+            });
+
+            autoClearEmptyRooms(latestRoomsData);
+        }
+
+        function autoClearEmptyRooms(roomsData) {
+            if (!window.firebaseDB) return;
+
+            Object.entries(roomsData).forEach(([roomName, roomData]) => {
+                if (!roomData) return;
+
+                const onlineCount = roomData.online ? Object.keys(roomData.online).length : 0;
+                if (onlineCount === 0 && roomData.messages) {
+                    const messagesRef = window.firebaseRef(window.firebaseDB, `rooms/${roomName}/messages`);
+                    window.firebaseRemove(messagesRef);
+                }
+            });
+        }
+
+        function updateRoomElement(element, name, count, isPlaceholder = false, slotNumber = null) {
+            const lamp = element.querySelector('.room-lamp');
+            const miceText = element.querySelector('.room-mice-text');
+            const iconsContainer = element.querySelector('.mouse-icons');
+            const nameSpan = element.querySelector('.room-name');
+            const createWrapper = element.querySelector('.room-create');
+            const actionButton = element.querySelector('.room-action');
+
+            const displayName = isPlaceholder ? '鼠窩沒鼠' : name;
+            if (nameSpan) {
+                nameSpan.textContent = displayName;
+            }
+
+            if (lamp) {
+                lamp.classList.toggle('on', count > 0);
+            }
+
+            const actualCount = Math.max(0, count || 0);
+            const clampedCount = Math.min(actualCount, 5);
+
+            if (miceText) {
+                miceText.textContent = `${actualCount} 隻老鼠`;
+            }
+
+            if (iconsContainer) {
+                iconsContainer.innerHTML = '';
+                for (let i = 0; i < clampedCount; i += 1) {
+                    iconsContainer.appendChild(createMouseIcon());
+                }
+            }
+
+            element.classList.toggle('has-users', count > 0 && !isPlaceholder);
+
+            if (isPlaceholder) {
+                if (createWrapper) {
+                    createWrapper.style.display = 'flex';
+                }
+                if (actionButton) {
+                    actionButton.style.display = 'none';
+                    actionButton.disabled = true;
+                    actionButton.dataset.room = '';
+                    actionButton.dataset.full = '0';
+                }
+            } else {
+                if (createWrapper) {
+                    createWrapper.style.display = 'none';
+                }
+                if (actionButton) {
+                    actionButton.style.display = 'inline-flex';
+                    actionButton.textContent = count >= 5 ? '已滿' : '加入';
+                    actionButton.disabled = count >= 5;
+                    actionButton.dataset.room = name;
+                    actionButton.dataset.full = count >= 5 ? '1' : '0';
+                    actionButton.onclick = () => window.enterRoom(name);
+                }
+            }
+
+            if (isPlaceholder && createWrapper) {
+                const input = createWrapper.querySelector('input[data-slot]');
+                if (input && slotNumber) {
+                    input.setAttribute('data-slot', slotNumber);
+                }
+                const button = createWrapper.querySelector('button[data-slot]');
+                if (button && slotNumber) {
+                    button.setAttribute('data-slot', slotNumber);
+                }
+            }
+        }
+
+        window.createRoomFromSlot = function(slotNumber) {
+            const input = document.querySelector(`.room-create input[data-slot="${slotNumber}"]`);
+            if (!input) {
+                return;
+            }
+
+            const roomName = input.value.trim();
+            if (!roomName) {
+                alert('請輸入鼠窩名稱');
+                return;
+            }
+
+            if (roomName.length > 20) {
+                alert('房間名稱不能超過 20 個字');
+                return;
+            }
+
+            input.value = '';
+            window.enterRoom(roomName);
+        };
+
+        async function recordVisit() {
+            if (!window.firebaseDB || visitRecorded || !currentUser) {
+                if (currentUser) {
+                    await updateLobbyPresence();
+                }
+                return;
+            }
+
+            try {
+                await updateLobbyPresence();
+
+                const visitsRef = window.firebaseRef(window.firebaseDB, 'stats/visits');
+                await window.firebasePush(visitsRef, {
+                    nickname: currentUser.nickname,
+                    isAdmin: currentUser.isAdmin,
+                    timestamp: Date.now()
+                });
+
+                if (currentUser.isAdmin) {
+                    const adminRef = window.firebaseRef(window.firebaseDB, `stats/adminLogins/${currentUser.nickname}`);
+                    await window.firebasePush(adminRef, {
+                        timestamp: Date.now()
+                    });
+                }
+
+                visitRecorded = true;
+            } catch (error) {
+                console.warn('紀錄瀏覽人次失敗', error);
+            }
+        }
+
+        function listenToLobbyPresence() {
+            if (!window.firebaseDB) return;
+
+            const lobbyRef = window.firebaseRef(window.firebaseDB, 'pageOnline');
+
+            if (lobbyListener) {
+                lobbyListener();
+            }
+
+            lobbyListener = window.firebaseOnValue(lobbyRef, (snapshot) => {
+                const lobbyData = snapshot.val() || {};
+                const count = Object.keys(lobbyData).length;
+                updateLobbyIndicator(count);
+            });
+        }
+
+        function updateLobbyIndicator(count) {
+            const lamp = document.getElementById('lobbyLamp');
+            const text = document.getElementById('lobbyStatusText');
+            if (!lamp || !text) return;
+
+            if (count > 0) {
+                lamp.classList.add('on');
+                text.textContent = `大廳有${count}隻老鼠`;
+            } else {
+                lamp.classList.remove('on');
+                text.textContent = '大廳沒有老鼠';
+            }
+        }
+
+        function formatTimestamp(timestamp) {
+            if (!timestamp) return '未知時間';
+            try {
+                return new Date(timestamp).toLocaleString('zh-TW', { hour12: false });
+            } catch (error) {
+                return '未知時間';
+            }
+        }
+
+        window.enterRoom = async function(roomName) {
+            if (!window.firebaseDB) {
+                alert('Firebase 未配置，無法使用即時功能');
+                return;
+            }
+
+            if (roomName === '鼠窩沒鼠' || roomName.startsWith('empty')) {
+                alert('此房間尚未命名或無人使用');
+                return;
+            }
+
+            if (!currentUser) {
+                if (!ensureUserProfile()) {
+                    return;
+                }
+            }
+
+            if (!roomsInitialized) {
+                await showRoomsSection();
+            }
+
+            const roomRef = window.firebaseRef(window.firebaseDB, `rooms/${roomName}/online`);
+            const snapshot = await new Promise(resolve => {
+                window.firebaseOnValue(roomRef, resolve, { onlyOnce: true });
+            });
+
+            const onlineUsers = snapshot.val() || {};
+            if (Object.keys(onlineUsers).length >= 5) {
+                alert('此房間已滿（最多 5 人）');
+                return;
+            }
+
+            currentRoom = roomName;
+
+            userPresenceRef = window.firebaseRef(window.firebaseDB, `rooms/${currentRoom}/online/${currentUser.id}`);
+            await window.firebaseSet(userPresenceRef, {
+                nickname: currentUser.nickname,
+                isAdmin: currentUser.isAdmin,
+                joinTime: Date.now()
+            });
+
+            window.firebaseOnDisconnect(userPresenceRef).remove();
+
+            document.getElementById('roomsSection').classList.add('hidden');
+            document.getElementById('chatPage').style.display = 'flex';
+            document.getElementById('currentRoomName').textContent = roomName;
+
+            const entryNotice = document.getElementById('entryNotice');
+            if (entryNotice) {
+                if (currentUser.isAdmin) {
+                    entryNotice.textContent = `登入身分：管理員（${currentUser.nickname}）`;
+                } else {
+                    entryNotice.textContent = `歡迎 ${currentUser.nickname}`;
+                }
+            }
+
+            const adminActions = document.getElementById('adminActions');
+            const clearChatBtn = document.getElementById('clearChatBtn');
+            const statsBtn = document.getElementById('statsBtn');
+
+            if (adminActions && clearChatBtn && statsBtn) {
+                if (currentUser.isAdmin) {
+                    adminActions.style.display = 'flex';
+                    clearChatBtn.style.display = 'inline-flex';
+                    statsBtn.style.display = currentUser.nickname === '吸鼠女' ? 'inline-flex' : 'none';
+                } else {
+                    adminActions.style.display = 'none';
+                    clearChatBtn.style.display = 'none';
+                    statsBtn.style.display = 'none';
+                }
+            }
+
+            listenToMessages();
+            listenToOnlineUsers();
+            startMessageCleanup();
+        };
+
+        function listenToMessages() {
+            if (!window.firebaseDB) return;
+
+            const messagesRef = window.firebaseRef(window.firebaseDB, `rooms/${currentRoom}/messages`);
+            const messagesQuery = window.firebaseQuery(
+                messagesRef,
+                window.firebaseOrderByChild('timestamp'),
+                window.firebaseLimitToLast(100)
+            );
+
+            if (messagesListener) {
+                messagesListener();
+            }
+
+            messagesListener = window.firebaseOnValue(messagesQuery, (snapshot) => {
+                const messagesData = snapshot.val();
+                displayMessages(messagesData);
+                handleMessageTimer(messagesData);
+            });
+        }
+
+        function listenToOnlineUsers() {
+            if (!window.firebaseDB) return;
+
+            const onlineRef = window.firebaseRef(window.firebaseDB, `rooms/${currentRoom}/online`);
+
+            if (onlineListener) {
+                onlineListener();
+            }
+
+            onlineListener = window.firebaseOnValue(onlineRef, (snapshot) => {
+                const onlineUsers = snapshot.val() || {};
+                const count = Object.keys(onlineUsers).length;
+                document.getElementById('roomOnlineCount').textContent = count;
+
+                if (count === 0 && currentRoom) {
+                    const messagesRef = window.firebaseRef(window.firebaseDB, `rooms/${currentRoom}/messages`);
+                    window.firebaseRemove(messagesRef);
+                    displayMessages(null);
+                    handleMessageTimer(null);
+                }
+            });
+        }
+
+        window.backToRooms = async function() {
+            if (userPresenceRef) {
+                await window.firebaseRemove(userPresenceRef);
+                userPresenceRef = null;
+            }
+
+            if (messagesListener) messagesListener();
+            if (onlineListener) onlineListener();
+            stopCountdown();
+            messageExpiryTimestamp = null;
+            if (cleanupInterval) {
+                clearInterval(cleanupInterval);
+                cleanupInterval = null;
+            }
+
+            document.getElementById('chatPage').style.display = 'none';
+            const roomsSection = document.getElementById('roomsSection');
+            roomsSection.classList.remove('hidden');
+            document.getElementById('messageTimer').style.display = 'none';
+            currentRoom = null;
+            document.getElementById('messageInput').value = '';
+            const adminActions = document.getElementById('adminActions');
+            if (adminActions) {
+                adminActions.style.display = 'none';
+            }
+            document.getElementById('clearChatBtn').style.display = 'none';
+            document.getElementById('statsBtn').style.display = 'none';
+            const entryNotice = document.getElementById('entryNotice');
+            if (entryNotice) {
+                entryNotice.textContent = '';
+            }
+
+            setRoomControlsEnabled(true);
+        };
+
+        window.handleKeyPress = function(event) {
+            if (event.key === 'Enter') {
+                window.sendMessage();
             }
         };
 
-        imageInput?.addEventListener("change", (event) => {
-            handleFiles(event.target.files);
-            event.target.value = "";
-        });
+        window.sendMessage = async function() {
+            if (!window.firebaseDB) {
+                alert('Firebase 未配置');
+                return;
+            }
 
-        $("#clearAll")?.addEventListener("click", () => {
-            images = [];
-            saveImages();
-            renderGallery();
-            showToast("🧹 已清除所有圖片");
-        });
+            if (!currentRoom) {
+                return;
+            }
 
-        const contextMenu = $("#contextMenu");
-        let currentImageId = null;
+            const messageInput = document.getElementById('messageInput');
+            const text = messageInput.value.trim();
 
-        const hideContextMenu = () => {
-            contextMenu?.classList.remove("show");
+            if (!text) return;
+
+            const messageData = {
+                userId: currentUser.id,
+                nickname: currentUser.nickname,
+                isAdmin: currentUser.isAdmin,
+                text: text,
+                timestamp: Date.now()
+            };
+
+            const messagesRef = window.firebaseRef(window.firebaseDB, `rooms/${currentRoom}/messages`);
+            await window.firebasePush(messagesRef, messageData);
+
+            messageInput.value = '';
+
+            messageExpiryTimestamp = messageData.timestamp + (60 * 60 * 1000);
+            startCountdown();
         };
 
-        const showContextMenu = (x, y) => {
-            if (!contextMenu) return;
-            const menuWidth = contextMenu.offsetWidth || 160;
-            const menuHeight = contextMenu.offsetHeight || 80;
-            const maxLeft = window.innerWidth - menuWidth - 12;
-            const maxTop = window.innerHeight - menuHeight - 12;
-            contextMenu.style.left = `${Math.min(x, maxLeft)}px`;
-            contextMenu.style.top = `${Math.min(y, maxTop)}px`;
-            contextMenu.classList.add("show");
-            setTimeout(() => {
-                document.addEventListener("click", hideContextMenu, { once: true });
-            }, 50);
-        };
+        function displayMessages(messagesData) {
+            const container = document.getElementById('messagesList');
+            container.innerHTML = '';
 
-        let pressTimer = null;
+            if (!messagesData) return;
 
-        const startPressTimer = (event, id) => {
-            clearTimeout(pressTimer);
-            pressTimer = setTimeout(() => {
-                currentImageId = id;
-                const point = event.touches ? event.touches[0] : event;
-                showContextMenu(point.clientX, point.clientY);
-            }, 450);
-        };
+            const messages = Object.entries(messagesData).map(([id, data]) => ({
+                id,
+                ...data
+            })).sort((a, b) => a.timestamp - b.timestamp);
 
-        const cancelPressTimer = () => {
-            clearTimeout(pressTimer);
-            pressTimer = null;
-        };
+            messages.forEach(msg => {
+                const messageDiv = document.createElement('div');
+                messageDiv.className = 'message-item';
+                if (msg.userId === currentUser.id) {
+                    messageDiv.classList.add('mine');
+                }
 
-        $("#imageGallery")?.addEventListener("mousedown", (event) => {
-            const card = event.target.closest(".card");
-            if (!card) return;
-            startPressTimer(event, card.dataset.id);
-        });
+                const nicknameSpan = document.createElement('div');
+                nicknameSpan.className = 'message-nickname';
+                nicknameSpan.textContent = msg.nickname;
+                if (msg.isAdmin) {
+                    const iconSpan = document.createElement('span');
+                    iconSpan.className = 'admin-icon';
+                    iconSpan.appendChild(createCrownIcon());
+                    nicknameSpan.appendChild(iconSpan);
+                }
+                messageDiv.appendChild(nicknameSpan);
 
-        $("#imageGallery")?.addEventListener("touchstart", (event) => {
-            const card = event.target.closest(".card");
-            if (!card) return;
-            startPressTimer(event, card.dataset.id);
-        });
+                const bubbleDiv = document.createElement('div');
+                bubbleDiv.className = msg.userId === currentUser.id ? 'message-bubble mine' : 'message-bubble others';
 
-        $$("#imageGallery, body").forEach((el) => {
-            el.addEventListener("mouseup", cancelPressTimer);
-            el.addEventListener("mouseleave", cancelPressTimer);
-            el.addEventListener("touchend", cancelPressTimer);
-            el.addEventListener("touchcancel", cancelPressTimer);
-        });
+                if (msg.text) {
+                    const textDiv = document.createElement('div');
+                    textDiv.textContent = msg.text;
+                    bubbleDiv.appendChild(textDiv);
+                }
 
-        $("#btnCopy")?.addEventListener("click", () => {
-            hideContextMenu();
-            if (!currentImageId) return;
-            const image = images.find((item) => item.id === currentImageId);
-            if (!image) return;
-            const url = `${location.origin}${location.pathname}#image-${encodeURIComponent(currentImageId)}`;
-            navigator.clipboard
-                .writeText(url)
-                .then(() => showToast("📋 已複製圖片連結"))
-                .catch(() => showToast("⚠️ 無法使用剪貼簿，請手動複製"));
-        });
-
-        const confirmOverlay = $("#confirmOverlay");
-        const confirmDeleteBtn = $("#confirmDelete");
-        const cancelDeleteBtn = $("#cancelDelete");
-
-        const showConfirm = () => {
-            confirmOverlay?.classList.add("show");
-            return new Promise((resolve) => {
-                const handleCancel = () => {
-                    cleanup();
-                    resolve(false);
-                };
-
-                const handleConfirm = () => {
-                    cleanup();
-                    resolve(true);
-                };
-
-                const handleOverlayClick = (event) => {
-                    if (event.target === confirmOverlay) {
-                        cleanup();
-                        resolve(false);
-                    }
-                };
-
-                const cleanup = () => {
-                    confirmOverlay?.classList.remove("show");
-                    cancelDeleteBtn?.removeEventListener("click", handleCancel);
-                    confirmDeleteBtn?.removeEventListener("click", handleConfirm);
-                    confirmOverlay?.removeEventListener("click", handleOverlayClick);
-                };
-
-                cancelDeleteBtn?.addEventListener("click", handleCancel, { once: true });
-                confirmDeleteBtn?.addEventListener("click", handleConfirm, { once: true });
-                confirmOverlay?.addEventListener("click", handleOverlayClick, { once: true });
+                messageDiv.appendChild(bubbleDiv);
+                container.appendChild(messageDiv);
             });
+
+            const messagesContainer = document.getElementById('messagesContainer');
+            messagesContainer.scrollTop = messagesContainer.scrollHeight;
+        }
+
+        function startMessageCleanup() {
+            if (cleanupInterval) {
+                clearInterval(cleanupInterval);
+            }
+
+            cleanOldMessages();
+            cleanupInterval = setInterval(() => {
+                cleanOldMessages();
+            }, 60000);
+        }
+
+        function handleMessageTimer(messagesData) {
+            const timerBadge = document.getElementById('messageTimer');
+
+            if (!messagesData) {
+                messageExpiryTimestamp = null;
+                timerBadge.style.display = 'none';
+                stopCountdown();
+                return;
+            }
+
+            const timestamps = Object.values(messagesData)
+                .map(message => message.timestamp)
+                .filter(ts => typeof ts === 'number');
+
+            if (timestamps.length === 0) {
+                messageExpiryTimestamp = null;
+                timerBadge.style.display = 'none';
+                stopCountdown();
+                return;
+            }
+
+            const oldestTimestamp = Math.min(...timestamps);
+            const nextExpiry = oldestTimestamp + (60 * 60 * 1000);
+
+            if (messageExpiryTimestamp !== nextExpiry) {
+                messageExpiryTimestamp = nextExpiry;
+                startCountdown();
+            } else if (!countdownInterval) {
+                startCountdown();
+            }
+        }
+
+        function startCountdown() {
+            if (countdownInterval) {
+                clearInterval(countdownInterval);
+            }
+
+            renderCountdown();
+            countdownInterval = setInterval(renderCountdown, 1000);
+        }
+
+        function stopCountdown() {
+            if (countdownInterval) {
+                clearInterval(countdownInterval);
+                countdownInterval = null;
+            }
+        }
+
+        function renderCountdown() {
+            const timerBadge = document.getElementById('messageTimer');
+
+            if (!messageExpiryTimestamp) {
+                timerBadge.style.display = 'none';
+                stopCountdown();
+                return;
+            }
+
+            const remainingSeconds = Math.max(0, Math.floor((messageExpiryTimestamp - Date.now()) / 1000));
+
+            if (remainingSeconds <= 0) {
+                timerBadge.style.display = 'none';
+                stopCountdown();
+                messageExpiryTimestamp = null;
+                return;
+            }
+
+            const minutes = Math.floor(remainingSeconds / 60);
+            const seconds = remainingSeconds % 60;
+
+            timerBadge.textContent = `${minutes}:${seconds.toString().padStart(2, '0')}`;
+            timerBadge.style.display = 'inline-block';
+        }
+
+        async function cleanOldMessages() {
+            if (!window.firebaseDB || !currentRoom) return;
+
+            const messagesRef = window.firebaseRef(window.firebaseDB, `rooms/${currentRoom}/messages`);
+            const snapshot = await new Promise(resolve => {
+                window.firebaseOnValue(messagesRef, resolve, { onlyOnce: true });
+            });
+
+            const messagesData = snapshot.val();
+            if (!messagesData) return;
+
+            const now = Date.now();
+            const oneHour = 60 * 60 * 1000;
+
+            Object.entries(messagesData).forEach(([messageId, messageData]) => {
+                if ((now - messageData.timestamp) > oneHour) {
+                    const messageRef = window.firebaseRef(window.firebaseDB, `rooms/${currentRoom}/messages/${messageId}`);
+                    window.firebaseRemove(messageRef);
+                }
+            });
+        }
+
+        window.showMenu = function() {
+            document.getElementById('menuModal').classList.add('show');
         };
 
-        $("#btnDelete")?.addEventListener("click", async () => {
-            hideContextMenu();
-            if (!currentImageId) return;
-            const confirmed = await showConfirm();
-            if (!confirmed) return;
+        window.closeMenu = function() {
+            document.getElementById('menuModal').classList.remove('show');
+        };
 
-            const latest = imgStore.read();
-            const next = latest.filter((item) => String(item.id) !== String(currentImageId));
-            images = next;
-            saveImages();
-            renderGallery();
-            showToast("🗑️ 圖片已刪除");
-            currentImageId = null;
+        window.clearChat = async function() {
+            if (!currentUser.isAdmin) {
+                alert('僅管理員可使用此功能');
+                return;
+            }
+
+            if (!confirm('確定要清空所有訊息嗎？')) {
+                return;
+            }
+
+            if (!window.firebaseDB) return;
+
+            const messagesRef = window.firebaseRef(window.firebaseDB, `rooms/${currentRoom}/messages`);
+            await window.firebaseRemove(messagesRef);
+
+            displayMessages(null);
+            handleMessageTimer(null);
+
+            document.getElementById('messageTimer').style.display = 'none';
+            messageExpiryTimestamp = null;
+            stopCountdown();
+
+            window.closeMenu();
+            alert('對話已清空');
+        };
+
+        window.showStats = async function() {
+            if (currentUser.nickname !== '吸鼠女') {
+                alert('僅吸鼠女可查看統計資料');
+                return;
+            }
+
+            if (!window.firebaseDB) return;
+
+            try {
+                const roomsRef = window.firebaseRef(window.firebaseDB, 'rooms');
+                const statsRef = window.firebaseRef(window.firebaseDB, 'stats');
+
+                const [roomsSnapshot, statsSnapshot] = await Promise.all([
+                    new Promise(resolve => {
+                        window.firebaseOnValue(roomsRef, resolve, { onlyOnce: true });
+                    }),
+                    new Promise(resolve => {
+                        window.firebaseOnValue(statsRef, resolve, { onlyOnce: true });
+                    })
+                ]);
+
+                const roomsData = roomsSnapshot.val() || {};
+                const statsData = statsSnapshot.val() || {};
+                const visitsData = statsData.visits || {};
+                const adminLogins = statsData.adminLogins || {};
+
+                const visitTimestamps = Object.values(visitsData)
+                    .map(entry => entry && entry.timestamp)
+                    .filter(ts => typeof ts === 'number')
+                    .sort((a, b) => b - a);
+
+                let statsText = '=== 使用統計 ===\n\n';
+                statsText += `網站瀏覽人次：${visitTimestamps.length}\n`;
+                if (visitTimestamps.length > 0) {
+                    statsText += '所有登入紀錄：\n';
+                    visitTimestamps.forEach(ts => {
+                        statsText += `- ${formatTimestamp(ts)}\n`;
+                    });
+                    statsText += '\n';
+                }
+
+                statsText += '=== 管理員登入 ===\n';
+                Object.keys(adminPasswords).forEach(adminName => {
+                    const entries = adminLogins[adminName] ? Object.values(adminLogins[adminName]) : [];
+                    const adminTimestamps = entries
+                        .map(entry => entry && entry.timestamp)
+                        .filter(ts => typeof ts === 'number')
+                        .sort((a, b) => b - a);
+
+                    statsText += `${adminName}：${adminTimestamps.length} 次\n`;
+                    if (adminTimestamps.length > 0) {
+                        statsText += '  登入時間：\n';
+                        adminTimestamps.forEach(ts => {
+                            statsText += `  - ${formatTimestamp(ts)}\n`;
+                        });
+                    }
+                    statsText += '\n';
+                });
+
+                statsText += '=== 房間概況 ===\n';
+                Object.keys(roomsData).forEach(roomName => {
+                    const room = roomsData[roomName] || {};
+                    const onlineCount = room.online ? Object.keys(room.online).length : 0;
+                    const messageCount = room.messages ? Object.keys(room.messages).length : 0;
+
+                    statsText += `房間：${roomName}\n`;
+                    statsText += `在線人數：${onlineCount}/5\n`;
+                    statsText += `訊息數量：${messageCount}\n`;
+
+                    if (room.online) {
+                        const users = Object.values(room.online).map(u => u.nickname).join(', ');
+                        statsText += `在線用戶：${users || '無'}\n`;
+                    }
+                    statsText += '\n';
+                });
+
+                alert(statsText.trim());
+            } catch (error) {
+                console.error('載入統計資料失敗', error);
+                alert('無法載入統計資料，請稍後再試');
+            }
+        };
+
+        window.logout = async function() {
+            if (!confirm('確定要登出嗎？')) {
+                return;
+            }
+
+            visitRecorded = false;
+
+            if (userPresenceRef) {
+                await window.firebaseRemove(userPresenceRef);
+                userPresenceRef = null;
+            }
+
+            if (messagesListener) messagesListener();
+            if (onlineListener) onlineListener();
+            if (allRoomsListener) allRoomsListener();
+            stopCountdown();
+            if (cleanupInterval) {
+                clearInterval(cleanupInterval);
+                cleanupInterval = null;
+            }
+            messageExpiryTimestamp = null;
+
+            currentUser = null;
+            currentRoom = null;
+            selectedAdmin = null;
+            roomsInitialized = false;
+
+            await updateLobbyPresence();
+
+            document.getElementById('chatPage').style.display = 'none';
+            const roomsSection = document.getElementById('roomsSection');
+            roomsSection.classList.remove('hidden');
+            document.getElementById('mainContainer').classList.remove('rooms-visible');
+            document.body.classList.remove('logged-in');
+
+            setRoomControlsEnabled(false);
+            listenToAllRooms();
+
+            const nicknameInput = document.getElementById('nicknameInput');
+            nicknameInput.value = '';
+            nicknameInput.removeAttribute('readonly');
+            nicknameInput.classList.remove('readonly');
+
+            const passwordInput = document.getElementById('adminPassword');
+            passwordInput.value = '';
+            passwordInput.style.display = 'none';
+
+            document.getElementById('messageInput').value = '';
+            document.getElementById('clearChatBtn').style.display = 'none';
+            document.getElementById('statsBtn').style.display = 'none';
+            const adminActions = document.getElementById('adminActions');
+            if (adminActions) {
+                adminActions.style.display = 'none';
+            }
+            const entryNotice = document.getElementById('entryNotice');
+            if (entryNotice) {
+                entryNotice.textContent = '';
+            }
+            document.getElementById('welcomeName').textContent = '';
+            document.getElementById('messageTimer').style.display = 'none';
+
+            document.querySelectorAll('.btn-admin').forEach(btn => {
+                btn.classList.remove('selected');
+            });
+
+            window.closeMenu();
+            updateLoginStatus();
+        };
+
+        window.addEventListener('beforeunload', async () => {
+            try {
+                if (userPresenceRef) {
+                    await window.firebaseRemove(userPresenceRef);
+                }
+                if (pagePresenceRef) {
+                    await window.firebaseRemove(pagePresenceRef);
+                }
+                if (lobbyListener) {
+                    lobbyListener();
+                }
+            } catch (error) {
+                console.warn('清除在線狀態時發生錯誤', error);
+            }
         });
-
-        renderGallery();
-        saveImages();
-
-        window.addEventListener("resize", () => hideContextMenu());
-        window.addEventListener("scroll", () => hideContextMenu());
     </script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- initialize visitor presence on load and update the lobby indicator while listening to room activity from the landing page
- tighten the lobby grid, keep all room controls on one view, and surface entry notices with inline admin action buttons in the chat header
- streamline room entry validation, expose admin-only chat tools, and expand the stats panel for 吸鼠女 with full visit and login histories

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e455fb63b08321959716825a814713